### PR TITLE
Add Next.js Kanban frontend skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.next/
+out/
+frontend/.env.local

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# crm
+# CRM Frontend
+
+This repository contains a simple frontend for managing vehicle sensor orders.
+
+The `/frontend` directory holds a Next.js project configured with Tailwind CSS and Zustand for state management. It implements a Kanban board with drag-and-drop to move orders between statuses.
+
+To get started:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Create `.env.local` from `.env.local.example` and set `NEXT_PUBLIC_API_URL` to your backend endpoint.

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=https://your-backend.railway.app

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,16 @@
+# Sensor Orders Kanban Frontend
+
+This is a Next.js + Tailwind CSS frontend for managing sensor orders in a Kanban board. It uses TypeScript and Zustand for state management.
+
+## Getting Started
+
+```bash
+npm install
+npm run dev
+```
+
+Create a `.env.local` file based on `.env.local.example` with your API URL.
+
+## Deployment
+
+The project can be deployed to Railway or Vercel. Run `npm run build` and follow your platform's instructions.

--- a/frontend/components/Column.tsx
+++ b/frontend/components/Column.tsx
@@ -1,0 +1,23 @@
+import { Draggable } from 'react-beautiful-dnd';
+import OrderCard from './OrderCard';
+import { Order } from '../lib/api';
+
+interface Props {
+  orders: Order[];
+}
+
+export default function Column({ orders }: Props) {
+  return (
+    <div className="space-y-2">
+      {orders.map((order, index) => (
+        <Draggable draggableId={order.id.toString()} index={index} key={order.id}>
+          {provided => (
+            <div ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps}>
+              <OrderCard order={order} />
+            </div>
+          )}
+        </Draggable>
+      ))}
+    </div>
+  );
+}

--- a/frontend/components/KanbanBoard.tsx
+++ b/frontend/components/KanbanBoard.tsx
@@ -1,0 +1,62 @@
+import { useEffect } from 'react';
+import { DragDropContext, Droppable, Draggable, DropResult } from 'react-beautiful-dnd';
+import create from 'zustand';
+import Column from './Column';
+import { fetchOrders, updateOrder, Order } from '../lib/api';
+
+interface State {
+  orders: Order[];
+  fetch: () => Promise<void>;
+  move: (id: number, status: Order['status']) => void;
+}
+
+export const useStore = create<State>((set, get) => ({
+  orders: [],
+  fetch: async () => {
+    const orders = await fetchOrders();
+    set({ orders });
+  },
+  move: async (id, status) => {
+    set({ orders: get().orders.map(o => (o.id === id ? { ...o, status } : o)) });
+    await updateOrder(id, status);
+  },
+}));
+
+const columns: Record<string, Order['status']> = {
+  pending: 'pending',
+  'in-progress': 'in-progress',
+  completed: 'completed',
+};
+
+export default function KanbanBoard() {
+  const { orders, fetch, move } = useStore();
+
+  useEffect(() => {
+    fetch();
+  }, [fetch]);
+
+  const onDragEnd = (result: DropResult) => {
+    if (!result.destination) return;
+    const id = Number(result.draggableId);
+    const newStatus = result.destination.droppableId as Order['status'];
+    move(id, newStatus);
+  };
+
+  return (
+    <DragDropContext onDragEnd={onDragEnd}>
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        {Object.entries(columns).map(([key, status]) => (
+          <Droppable droppableId={status} key={status}>
+            {provided => (
+              <div ref={provided.innerRef} {...provided.droppableProps} className="bg-white dark:bg-gray-800 p-2 rounded shadow">
+                <h2 className="font-semibold mb-2 capitalize">{status.replace('-', ' ')}</h2>
+                <Column orders={orders.filter(o => o.status === status)} />
+                {provided.placeholder}
+              </div>
+            )}
+          </Droppable>
+        ))}
+      </div>
+    </DragDropContext>
+  );
+}

--- a/frontend/components/OrderCard.tsx
+++ b/frontend/components/OrderCard.tsx
@@ -1,0 +1,27 @@
+import Image from 'next/image';
+import { Order } from '../lib/api';
+import OrderModal from './OrderModal';
+import { useState } from 'react';
+
+interface Props {
+  order: Order;
+}
+
+export default function OrderCard({ order }: Props) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="bg-gray-50 dark:bg-gray-700 p-2 rounded shadow" onClick={() => setOpen(true)}>
+      <div className="flex items-center space-x-2">
+        <div className="w-16 h-16 relative flex-shrink-0">
+          <Image src={order.image_url} alt={order.sensor_type} fill className="object-cover rounded" />
+        </div>
+        <div className="flex-1">
+          <p className="text-sm font-medium">{order.year} {order.brand} {order.model}</p>
+          <p className="text-xs text-gray-500">{order.sensor_type} - {order.position}</p>
+          <p className="text-xs font-semibold">${order.price_usd.toFixed(2)} vs ${order.competitor_price.toFixed(2)}</p>
+        </div>
+      </div>
+      <OrderModal order={order} open={open} onOpenChange={setOpen} />
+    </div>
+  );
+}

--- a/frontend/components/OrderModal.tsx
+++ b/frontend/components/OrderModal.tsx
@@ -1,0 +1,30 @@
+import * as Dialog from '@radix-ui/react-dialog';
+import { Order } from '../lib/api';
+
+interface Props {
+  order: Order;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function OrderModal({ order, open, onOpenChange }: Props) {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/50" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 w-11/12 max-w-lg -translate-x-1/2 -translate-y-1/2 bg-white dark:bg-gray-800 p-4 rounded">
+          <Dialog.Title className="text-lg font-bold mb-2">Order #{order.id}</Dialog.Title>
+          <p className="mb-1"><strong>Vehicle:</strong> {order.year} {order.brand} {order.model}</p>
+          <p className="mb-1"><strong>VIN:</strong> {order.vin}</p>
+          <p className="mb-1"><strong>Address:</strong> {order.address}</p>
+          <p className="mb-1"><strong>Notes:</strong> {order.application_notes}</p>
+          <p className="mb-1"><strong>Stock:</strong> {order.stock}</p>
+          <div className="mt-4 flex justify-end space-x-2">
+            <button className="px-3 py-1 bg-gray-200 rounded" onClick={() => onOpenChange(false)}>Close</button>
+            <button className="px-3 py-1 bg-blue-600 text-white rounded" disabled>Generate Invoice</button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,0 +1,38 @@
+export interface Order {
+  id: number;
+  client_phone: string;
+  brand: string;
+  model: string;
+  year: string;
+  component: string;
+  vin: string;
+  address: string;
+  status: 'pending' | 'in-progress' | 'completed';
+  timestamp: string;
+  sensor_type: string;
+  manufacturer_code: string;
+  internal_part_number: string;
+  position: string;
+  application_notes: string;
+  stock: number;
+  price_usd: number;
+  competitor_price: number;
+  category: string;
+  image_url: string;
+}
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL;
+
+export async function fetchOrders(): Promise<Order[]> {
+  const res = await fetch(`${API_URL}/orders`);
+  if (!res.ok) throw new Error('Failed to fetch');
+  return res.json();
+}
+
+export async function updateOrder(id: number, status: string) {
+  await fetch(`${API_URL}/orders/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ status }),
+  });
+}

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  images: {
+    domains: ['example.com'],
+  },
+};
+
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "sensor-kanban-frontend",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "typescript": "5.4.2",
+    "tailwindcss": "3.4.3",
+    "postcss": "8.4.38",
+    "autoprefixer": "10.4.17",
+    "@headlessui/react": "^1.7.7",
+    "@heroicons/react": "2.0.18",
+    "zustand": "4.5.2",
+    "@tanstack/react-query": "4.36.1",
+    "clsx": "2.0.0",
+    "react-beautiful-dnd": "13.1.1",
+    "@radix-ui/react-dialog": "1.0.4",
+    "sonner": "1.1.0"
+  }
+}

--- a/frontend/pages/dashboard.tsx
+++ b/frontend/pages/dashboard.tsx
@@ -1,0 +1,16 @@
+import Head from 'next/head';
+import KanbanBoard from '../components/KanbanBoard';
+import '../styles/globals.css';
+
+export default function Dashboard() {
+  return (
+    <>
+      <Head>
+        <title>Sensor Orders Dashboard</title>
+      </Head>
+      <main className="min-h-screen p-4 bg-gray-100 dark:bg-gray-900">
+        <KanbanBoard />
+      </main>
+    </>
+  );
+}

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,0 +1,9 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html,
+body,
+#__next {
+  height: 100%;
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './pages/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- initialize Next.js frontend skeleton under `/frontend`
- configure TailwindCSS and Zustand state management
- implement Kanban board with drag-and-drop
- add basic modal for order details
- provide README with setup instructions

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688460541a4083258e942c2404a5a2ce