### PR TITLE
Fix 404 on Vercel by handling global CSS properly

### DIFF
--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,0 +1,6 @@
+import type { AppProps } from 'next/app';
+import '../styles/globals.css';
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,6 +1,5 @@
 import Head from 'next/head';
 import KanbanBoard from '../components/KanbanBoard';
-import '../styles/globals.css';
 
 export default function Dashboard() {
   return (


### PR DESCRIPTION
## Summary
- add Next.js `_app.tsx` to load `globals.css`
- remove global CSS import from `index.tsx`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688462922acc8325a2aeb6007c32cf34