### PR TITLE
Complete Kanban dashboard

### DIFF
--- a/frontend/components/KanbanBoard.tsx
+++ b/frontend/components/KanbanBoard.tsx
@@ -1,8 +1,9 @@
-import { useEffect } from 'react';
-import { DragDropContext, Droppable, Draggable, DropResult } from 'react-beautiful-dnd';
+import { useEffect, useState } from 'react';
+import { DragDropContext, Droppable, DropResult } from 'react-beautiful-dnd';
 import create from 'zustand';
 import Column from './Column';
 import { fetchOrders, updateOrder, Order } from '../lib/api';
+import { Toaster, toast } from 'sonner';
 
 interface State {
   orders: Order[];
@@ -18,22 +19,40 @@ export const useStore = create<State>((set, get) => ({
   },
   move: async (id, status) => {
     set({ orders: get().orders.map(o => (o.id === id ? { ...o, status } : o)) });
-    await updateOrder(id, status);
+    try {
+      await updateOrder(id, status);
+      toast.success(`Order #${id} moved to ${status.replace('_', ' ')}`);
+    } catch (err) {
+      toast.error('Failed to update order');
+    }
   },
 }));
 
 const columns: Record<string, Order['status']> = {
   pending: 'pending',
-  'in-progress': 'in-progress',
+  in_progress: 'in_progress',
   completed: 'completed',
 };
 
 export default function KanbanBoard() {
   const { orders, fetch, move } = useStore();
+  const [query, setQuery] = useState('');
+  const [dark, setDark] = useState(false);
 
   useEffect(() => {
     fetch();
   }, [fetch]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme');
+    if (stored === 'dark') setDark(true);
+  }, []);
+
+  useEffect(() => {
+    if (dark) document.documentElement.classList.add('dark');
+    else document.documentElement.classList.remove('dark');
+    localStorage.setItem('theme', dark ? 'dark' : 'light');
+  }, [dark]);
 
   const onDragEnd = (result: DropResult) => {
     if (!result.destination) return;
@@ -42,15 +61,42 @@ export default function KanbanBoard() {
     move(id, newStatus);
   };
 
+  const filtered = orders.filter(o => {
+    const q = query.toLowerCase();
+    return (
+      o.brand.toLowerCase().includes(q) ||
+      o.model.toLowerCase().includes(q) ||
+      o.vin.toLowerCase().includes(q) ||
+      o.sensor_type.toLowerCase().includes(q) ||
+      o.manufacturer_code.toLowerCase().includes(q) ||
+      o.internal_part_number.toLowerCase().includes(q)
+    );
+  });
+
   return (
     <DragDropContext onDragEnd={onDragEnd}>
+      <Toaster position="top-right" />
+      <div className="mb-4 flex items-center justify-between">
+        <input
+          className="w-full md:w-1/3 px-2 py-1 border rounded mr-2 dark:bg-gray-700 dark:border-gray-600"
+          placeholder="Search orders..."
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+        />
+        <button
+          onClick={() => setDark(!dark)}
+          className="px-3 py-1 rounded bg-gray-200 dark:bg-gray-700 dark:text-gray-200"
+        >
+          {dark ? 'Light' : 'Dark'}
+        </button>
+      </div>
       <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
         {Object.entries(columns).map(([key, status]) => (
           <Droppable droppableId={status} key={status}>
             {provided => (
               <div ref={provided.innerRef} {...provided.droppableProps} className="bg-white dark:bg-gray-800 p-2 rounded shadow">
-                <h2 className="font-semibold mb-2 capitalize">{status.replace('-', ' ')}</h2>
-                <Column orders={orders.filter(o => o.status === status)} />
+                <h2 className="font-semibold mb-2 capitalize">{status.replace('_', ' ')}</h2>
+                <Column orders={filtered.filter(o => o.status === status)} />
                 {provided.placeholder}
               </div>
             )}

--- a/frontend/components/OrderCard.tsx
+++ b/frontend/components/OrderCard.tsx
@@ -16,9 +16,10 @@ export default function OrderCard({ order }: Props) {
           <Image src={order.image_url} alt={order.sensor_type} fill className="object-cover rounded" />
         </div>
         <div className="flex-1">
-          <p className="text-sm font-medium">{order.year} {order.brand} {order.model}</p>
-          <p className="text-xs text-gray-500">{order.sensor_type} - {order.position}</p>
-          <p className="text-xs font-semibold">${order.price_usd.toFixed(2)} vs ${order.competitor_price.toFixed(2)}</p>
+          <p className="text-sm font-medium">{order.year} {order.brand} {order.model} - {order.component}</p>
+          <p className="text-xs text-gray-500">VIN: {order.vin}</p>
+          <p className="text-xs">{order.sensor_type} | {order.manufacturer_code} | {order.internal_part_number}</p>
+          <p className="text-xs font-semibold">Stock: {order.stock} - ${order.price_usd.toFixed(2)} vs ${order.competitor_price.toFixed(2)}</p>
         </div>
       </div>
       <OrderModal order={order} open={open} onOpenChange={setOpen} />

--- a/frontend/components/OrderModal.tsx
+++ b/frontend/components/OrderModal.tsx
@@ -14,11 +14,15 @@ export default function OrderModal({ order, open, onOpenChange }: Props) {
         <Dialog.Overlay className="fixed inset-0 bg-black/50" />
         <Dialog.Content className="fixed left-1/2 top-1/2 w-11/12 max-w-lg -translate-x-1/2 -translate-y-1/2 bg-white dark:bg-gray-800 p-4 rounded">
           <Dialog.Title className="text-lg font-bold mb-2">Order #{order.id}</Dialog.Title>
-          <p className="mb-1"><strong>Vehicle:</strong> {order.year} {order.brand} {order.model}</p>
+          <p className="mb-1"><strong>Vehicle:</strong> {order.year} {order.brand} {order.model} - {order.component}</p>
           <p className="mb-1"><strong>VIN:</strong> {order.vin}</p>
           <p className="mb-1"><strong>Address:</strong> {order.address}</p>
           <p className="mb-1"><strong>Notes:</strong> {order.application_notes}</p>
+          <p className="mb-1"><strong>Sensor:</strong> {order.sensor_type}</p>
+          <p className="mb-1"><strong>Manufacturer Code:</strong> {order.manufacturer_code}</p>
+          <p className="mb-1"><strong>Internal Part:</strong> {order.internal_part_number}</p>
           <p className="mb-1"><strong>Stock:</strong> {order.stock}</p>
+          <p className="mb-1"><strong>Price:</strong> ${order.price_usd.toFixed(2)} (Competitor ${order.competitor_price.toFixed(2)})</p>
           <div className="mt-4 flex justify-end space-x-2">
             <button className="px-3 py-1 bg-gray-200 rounded" onClick={() => onOpenChange(false)}>Close</button>
             <button className="px-3 py-1 bg-blue-600 text-white rounded" disabled>Generate Invoice</button>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -7,7 +7,7 @@ export interface Order {
   component: string;
   vin: string;
   address: string;
-  status: 'pending' | 'in-progress' | 'completed';
+  status: 'pending' | 'in_progress' | 'completed';
   timestamp: string;
   sensor_type: string;
   manufacturer_code: string;

--- a/frontend/pages/404.tsx
+++ b/frontend/pages/404.tsx
@@ -1,0 +1,7 @@
+export default function NotFound() {
+  return (
+    <div className="flex h-screen items-center justify-center bg-gray-100 dark:bg-gray-900">
+      <h1 className="text-2xl font-semibold text-gray-700 dark:text-gray-200">Page Not Found</h1>
+    </div>
+  );
+}

--- a/frontend/pages/dashboard.tsx
+++ b/frontend/pages/dashboard.tsx
@@ -1,0 +1,15 @@
+import Head from 'next/head';
+import KanbanBoard from '../components/KanbanBoard';
+
+export default function Dashboard() {
+  return (
+    <>
+      <Head>
+        <title>Sensor Orders Dashboard</title>
+      </Head>
+      <main className="min-h-screen p-4 bg-gray-100 dark:bg-gray-900">
+        <KanbanBoard />
+      </main>
+    </>
+  );
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,15 +1,12 @@
-import Head from 'next/head';
-import KanbanBoard from '../components/KanbanBoard';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 
-export default function Dashboard() {
-  return (
-    <>
-      <Head>
-        <title>Sensor Orders Dashboard</title>
-      </Head>
-      <main className="min-h-screen p-4 bg-gray-100 dark:bg-gray-900">
-        <KanbanBoard />
-      </main>
-    </>
-  );
+export default function Index() {
+  const router = useRouter();
+
+  useEffect(() => {
+    router.replace('/dashboard');
+  }, [router]);
+
+  return null;
 }


### PR DESCRIPTION
## Summary
- add `/dashboard` route and redirect `/` to it
- add custom 404 page
- enhance `KanbanBoard` with search, dark mode and toasts
- display more order info in cards and modal
- update status values to `in_progress`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68846753f9ec83258a9aab16f1ce427e